### PR TITLE
Allow try out via querystring parameters

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -37,12 +37,10 @@
 
 <environment include="Development">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.min.js" integrity="sha256-ngFW3UnAN0Tnm76mDuu7uUtYEcG3G5H1+zioJw3t+68=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.19.2/axios.min.js" integrity="sha256-T/f7Sju1ZfNNfBh7skWn0idlCBcI3RwdLSS4/I7NQKQ=" crossorigin="anonymous"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
 </environment>
 <environment exclude="Development">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.min.js" integrity="sha256-ngFW3UnAN0Tnm76mDuu7uUtYEcG3G5H1+zioJw3t+68=" crossorigin="anonymous"></script>    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.16/vue.min.js" integrity="sha256-TaLceMwjWRqe4yhbqPOJH6V7UGt5AvvdNfpaIXJWbFU=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.19.2/axios.min.js" integrity="sha256-T/f7Sju1ZfNNfBh7skWn0idlCBcI3RwdLSS4/I7NQKQ=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.min.js" integrity="sha256-ngFW3UnAN0Tnm76mDuu7uUtYEcG3G5H1+zioJw3t+68=" crossorigin="anonymous"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
 </environment>
 

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -42,6 +42,15 @@
     },
     
     beforeMount() {
+
+        let urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has('template')) {
+            this.template = urlParams.get('template');
+        }
+        if (urlParams.has('model')) {
+            this.model = urlParams.get('model');
+        }
+        
         this.generate();
     }
 });

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -25,19 +25,31 @@
     },
 
     methods: {
-        generate() {
+        async generate() {
             this.loading = true;
-            axios.post('/generate', {
-                model: this.model,
-                template: this.template,
-                output: this.output
-            }).then(response => {
-                this.output = response.data.output;
-            }).catch(response => {
-                alert(response);
-            }).finally(x => {
+
+            try {
+                const response = await fetch('/generate', {
+                    method: 'POST',
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: this.model,
+                        template: this.template,
+                        output: this.output
+                    })
+                });
+
+                if (!response.ok) throw new Error(`Request failed with status code ${response.status}`);
+
+                const data = await response.json();
+                this.output = data.output;
+            } catch (e) {
+                alert(e)
+            } finally {
                 this.loading = false;
-            });
+            }
         }
     },
     


### PR DESCRIPTION
This PR allows using the querystring to set the `template` and the `model`

As a bonus I have removed the dependency of `axios` by using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) 

> This is in preparation of https://github.com/scriban/scriban/pull/603 I'm working on to add a `Try Out` link to each Built in scriban method, see [builtins](https://github.com/scriban/scriban/blob/master/doc/builtins.md)